### PR TITLE
Improve build speed by caching next build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,15 @@ jobs:
           cache: yarn
           cache-dependency-path: yarn.lock
 
+      - name: Cache Next.js build
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Install dependencies
         run: yarn install
 


### PR DESCRIPTION
.next/cache is a directory generated at build time, and caching the files generated at build time can improve build speed.
By using cache in CI, build speed can be improved.
