### PR TITLE
Update dependencies and renovate settings

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,4 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>kitsuyui/renovate-config'],
-  // https://github.com/renovatebot/renovate/issues/19038
-  // https://github.com/renovatebot/renovate/issues/21438
-  // TODO: remove this when renovatebot/renovate#21438 is fixed
-  rangeStrategy: 'bump',
 }

--- a/packages/simple/package.json
+++ b/packages/simple/package.json
@@ -20,7 +20,7 @@
     "@types/node": "20.14.10",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "typedoc": "^0.26.3",
+    "typedoc": "^0.26.4",
     "typescript": "5.5.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         specifier: 18.3.0
         version: 18.3.0
       typedoc:
-        specifier: ^0.26.3
+        specifier: ^0.26.4
         version: 0.26.4(typescript@5.5.3)
       typescript:
         specifier: 5.5.3
@@ -427,8 +427,8 @@ packages:
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
-  electron-to-chromium@1.4.825:
-    resolution: {integrity: sha512-OCcF+LwdgFGcsYPYC5keEEFC2XT0gBhrYbeGzHCx7i9qRFbzO/AqTmc/C/1xNhJj+JA7rzlN7mpBuStshh96Cg==}
+  electron-to-chromium@1.4.827:
+    resolution: {integrity: sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1258,7 +1258,7 @@ snapshots:
   browserslist@4.23.2:
     dependencies:
       caniuse-lite: 1.0.30001641
-      electron-to-chromium: 1.4.825
+      electron-to-chromium: 1.4.827
       node-releases: 2.0.14
       update-browserslist-db: 1.1.0(browserslist@4.23.2)
 
@@ -1417,7 +1417,7 @@ snapshots:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
 
-  electron-to-chromium@1.4.825: {}
+  electron-to-chromium@1.4.827: {}
 
   emoji-regex@8.0.0: {}
 


### PR DESCRIPTION
- Update dependencies
- Support rangeStrategy=update-lockfile for pnpm is now available
  - So we can no longer use the workaround for pnpm

https://github.com/renovatebot/renovate/issues/21438
